### PR TITLE
feat(image): dockerfile enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github/
+logos/
+screenshots/
+.gitignore
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,32 @@
-FROM clojure:openjdk-11-tools-deps
-MAINTAINER Kiran Shila <me@kiranshila.com>
-COPY . /home/Doplarr
-CMD ["java","-jar","/home/Doplarr/target/Doplarr.jar"]
+FROM clojure:openjdk-11-tools-deps-slim-buster
+
+ENV \
+  DEBCONF_NONINTERACTIVE_SEEN=true \
+  DEBIAN_FRONTEND="noninteractive"
+
+WORKDIR /app
+
+RUN \
+  apt-get -qq update \
+  && apt-get install -qy \
+    ca-certificates \
+    tini \
+    tzdata \
+  && \
+  apt-get remove -y jq \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && \
+  rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/cache/apt/* \
+    /var/tmp/*
+
+COPY . /app
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["java","-jar","/app/target/Doplarr.jar"]
+
+LABEL "maintainer"="Kiran Shila <me@kiranshila.com>"
+LABEL "org.opencontainers.image.source"="https://github.com/kiranshila/Doplarr"


### PR DESCRIPTION
Several improvements to the Dockerfile:

- Switch to `clojure:openjdk-11-tools-deps-slim-buster` as the base (~100MB difference in size)
- Install the `ca-certificates`, `tini` and `tzdata` packages.
- Set `ENTRYPOINT` to use `tini`
- Switch jar path to `/app/target/Doplarr.jar`
- Update labels and remove deprecated `MAINTAINER` label.
- Include a `.dockerignore` file.