### PR TITLE
Trace-level HTTP logging

### DIFF
--- a/src/doplarr/interaction_state_machine.clj
+++ b/src/doplarr/interaction_state_machine.clj
@@ -116,12 +116,12 @@
                           :embed (m/create-message! messaging channel-id (discord/request-performed-embed embed user-id))
                           (m/create-message! messaging channel-id (discord/request-performed-plain payload media-type user-id)))))))
             (else (fn [e]
-                    (let [{:keys [status body] :as data} (ex-data e)]
+                    (let [{:keys [status body]} (ex-data e)]
                       (if (= status 403)
                         (->> @(m/edit-original-interaction-response! messaging bot-id token (discord/content-response (body "message")))
                              (else #(fatal % "Error in sending request failure response")))
                         (->> @(m/edit-original-interaction-response! messaging bot-id token (discord/content-response "Unspecified error on request, check logs"))
-                             (then #(fatal data "Non 403 error on request"))
+                             (then #(fatal % "Non 403 error on request"))
                              (else #(fatal % "Error in sending error response")))))))))))
 
 (defn continue-interaction! [interaction]

--- a/src/doplarr/utils.clj
+++ b/src/doplarr/utils.clj
@@ -8,7 +8,7 @@
    [doplarr.state :as state]
    [fmnoise.flow :as flow :refer [else then]]
    [hato.client :as hc]
-   [taoensso.timbre :refer [fatal]]))
+   [taoensso.timbre :refer [fatal trace]]))
 
 (defn deep-merge [a & maps]
   (if (map? a)
@@ -18,6 +18,7 @@
 (defn http-request [method url key & [params]]
   (let [chan (a/promise-chan)
         put (partial a/put! chan)]
+    (trace "Performing HTTP request" method url params)
     (hc/request
      (deep-merge
       {:method method


### PR DESCRIPTION
Adds trace-level logging for all doplarr-based http requests.

Fixes a logging bug on non-403 overseerr errors