### PR TITLE
Docker-compose typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Alternatively, use docker-compose:
 
 ```yaml
 doplarr:
-  environment
+  environment:
     - SONARR__URL=http://localhost:8989
     - RADARR__URL=http://localhost:7878
     - SONARR__API=sonarr_api


### PR DESCRIPTION
Ran into an issue when setting up the docker-compose, turns out it was just because it's missing a semicolon after "environment" lol.

Added ":" after environment in docker-compose