### PR TITLE
Bug: Fix for Query with Special Characters Failing Against Overseer

### DIFF
--- a/config.edn
+++ b/config.edn
@@ -1,10 +1,8 @@
-{:sonarr/url ""
- :sonarr/api ""
- :radarr/url ""
- :radarr/api ""
- ; :overseerr/url ""
- ; :overseerr/api ""
- :discord/token ""
+{
+ :overseerr/url "http://192.168.1.200:9002"
+ :overseerr/api "MTcwNDMwMDUwNTE5MjE5ZTQ4YjAxLWE4N2ItNDIxYS04OWVhLTU2ZGJmMmViYjM0MA=="
+ :discord/token "MTIwNDE1MDcyNDI3NTk5NDY1NA.GaK00w.LMWbegi1-5TNJxd3CVCjfvBeEJXT6mKKwtPXC0"
+ :overseerr/default-id 1
  ; -- Optional Settings
  ; :partial-seasons false
  ; :sonarr/quality-profile ""
@@ -14,6 +12,5 @@
  ; :sonarr/rootfolder ""
  ; :sonarr/season-folders true
  ; :discord/max-results 10
- ; :overseerr/default-id 1
- ; :log-level :trace
+ :log-level :trace
  }

--- a/config.edn
+++ b/config.edn
@@ -1,8 +1,10 @@
-{
- :overseerr/url "http://192.168.1.200:9002"
- :overseerr/api "MTcwNDMwMDUwNTE5MjE5ZTQ4YjAxLWE4N2ItNDIxYS04OWVhLTU2ZGJmMmViYjM0MA=="
- :discord/token "MTIwNDE1MDcyNDI3NTk5NDY1NA.GaK00w.LMWbegi1-5TNJxd3CVCjfvBeEJXT6mKKwtPXC0"
- :overseerr/default-id 1
+{:sonarr/url ""
+ :sonarr/api ""
+ :radarr/url ""
+ :radarr/api ""
+ ; :overseerr/url ""
+ ; :overseerr/api ""
+ :discord/token ""
  ; -- Optional Settings
  ; :partial-seasons false
  ; :sonarr/quality-profile ""
@@ -12,5 +14,6 @@
  ; :sonarr/rootfolder ""
  ; :sonarr/season-folders true
  ; :discord/max-results 10
- :log-level :trace
+ ; :overseerr/default-id 1
+ ; :log-level :trace
  }

--- a/src/doplarr/backends/overseerr.clj
+++ b/src/doplarr/backends/overseerr.clj
@@ -10,7 +10,7 @@
     (utils/request-and-process-body
      impl/GET
      (partial impl/process-search-result type)
-     (str "/search?query=" term))))
+     (str "/search?query=" (utils/url-encode-illegal-characters term)))))
 
 ; In Overseerr, the only additional option we'll need is which season,
 ; if the request type is a series

--- a/src/doplarr/utils.clj
+++ b/src/doplarr/utils.clj
@@ -8,6 +8,7 @@
    [doplarr.state :as state]
    [fmnoise.flow :as flow :refer [else then]]
    [hato.client :as hc]
+   [hato.middleware :as hm]
    [taoensso.timbre :refer [fatal trace]]
    [clojure.set :as set]))
 
@@ -83,6 +84,17 @@
       (#(if (str/ends-with? % "id")
           (str/trim (subs % 0 (- (count %) 2)))
           (str/trim %)))))
+
+(defn url-encode-illegal-characters
+  "Takes a raw url path or query and url-encodes any illegal characters.
+  Minimizes ambiguity by encoding space to %20."
+  [path-or-query]
+  (when path-or-query
+    (-> path-or-query
+        (str/replace " " "%20")
+        (str/replace
+         #"[^a-zA-Z0-9]"
+         hm/url-encode))))
 
 (defn media-fn
   "Resolves a function `f` in the backend namespace matching the available backend for a given `media`"

--- a/src/doplarr/utils.clj
+++ b/src/doplarr/utils.clj
@@ -91,10 +91,8 @@
   [path-or-query]
   (when path-or-query
     (-> path-or-query
-        (str/replace " " "%20")
-        (str/replace
-         #"[^a-zA-Z0-9]"
-         hm/url-encode))))
+        (str/replace #"[^a-zA-Z0-9]" hm/url-encode)
+        (str/replace "+" "%20"))))
 
 (defn media-fn
   "Resolves a function `f` in the backend namespace matching the available backend for a given `media`"


### PR DESCRIPTION
- Modified Overseerr call to encode the query parameter
- Added new util function, url-encode-illegal-characters (sources from hato.middleware) but with URL encoding all non alpha-numeric characters.