### PR TITLE
fix: support discordIds array format for Seerr 3.3 compatibility

### DIFF
--- a/src/doplarr/backends/overseerr/impl.clj
+++ b/src/doplarr/backends/overseerr/impl.clj
@@ -100,17 +100,21 @@
                      (into [])))
          (else #(fatal % "Exception on querying Overseerr users")))))
 
-(defn discord-id [ovsr-id]
+(defn discord-ids [ovsr-id]
   (a/go
     (->> (a/<! (GET (str "/user/" ovsr-id)))
-         (then #(->> (utils/from-camel %)
-                     (s/select-one [:body :settings :discord-id])))
-         (else #(fatal % "Exception on querying Overseerr discord id")))))
+         (then (fn [result]
+                 (let [settings (s/select-one [:body :settings] (utils/from-camel result))]
+                   (or (seq (:discord-ids settings))
+                       (when-let [id (:discord-id settings)] [id])
+                       []))))
+         (else #(fatal % "Exception on querying Overseerr discord ids")))))
 
 (defn discord-users []
   (a/go-loop [ids (a/<! (all-users))
               users {}]
     (if (empty? ids)
       users
-      (let [id (first ids)]
-        (recur (rest ids) (assoc users (a/<! (discord-id id)) id))))))
+      (let [id (first ids)
+            disc-ids (a/<! (discord-ids id))]
+        (recur (rest ids) (merge users (into {} (map #(vector % id) disc-ids))))))))


### PR DESCRIPTION
Seerr v3.3.0 renamed the discordId (string) field to discordIds (array) in user settings. This caused all Discord user lookups to fail with "unauthorized" since the mapping always came back empty.

- Read discordIds (array) first, fall back to discordId (string) for older Overseerr/Jellyseerr installs
- Support multiple Discord IDs per user in the discord-users mapping

fyi this is vibed but it is working locally for me